### PR TITLE
Removed misleading information regarding `dkms` usage from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ Note: change `VER` to the desired module version.
 
 ```sh
 sudo dkms ldtarball --archive=huawei-wmi-VER-source-only.dkms.tar.gz
-# For autoinstallation
-sudo dkms autoinstall -m huawei-wmi/VER
-# For one-time installation
 sudo dkms install huawei-wmi/VER
 ```
 3. Reboot


### PR DESCRIPTION
Caused #58.