### PR TITLE
Added support for Honor laptops in hwdb

### DIFF
--- a/99-Huawei.hwdb
+++ b/99-Huawei.hwdb
@@ -5,6 +5,7 @@ evdev:atkbd:dmi:bvn*:bvr*:svnHUAWEI*:pnMACH-WX9:pvr*
  KEYBOARD_KEY_281=unknown
  KEYBOARD_KEY_282=unknown
 
-# Huawei microphone mute
+# Huawei & Honor microphone mute
 evdev:name:Huawei WMI hotkeys:dmi:bvn*:bvr*:bd*:svnHUAWEI*
+evdev:name:Huawei WMI hotkeys:dmi:bvn*:bvr*:bd*:svnHONOR*
  KEYBOARD_KEY_287=f20         # Microphone mute button, should be micmute


### PR DESCRIPTION
According to a recent (?) DMI change from the manufacturer.

P.S. Also preferred to be cherry-picked into `feat/kbdlight` as I use that and do maintain an [AUR package](https://aur.archlinux.org/packages/huawei-wmi-dkms-kbdlight-git) for it (currently from @sermart1234's fork, but subject to change when more features are merged).