### PR TITLE
Ignore Ambient Light Sensoring

### DIFF
--- a/huawei-wmi.c
+++ b/huawei-wmi.c
@@ -82,6 +82,8 @@ static const struct key_entry huawei_wmi_keymap[] = {
 	{ KE_KEY,    0x289, { KEY_WLAN } },
 	// Huawei |M| key
 	{ KE_KEY,    0x28a, { KEY_CONFIG } },
+	// Unknown key event
+	{ KE_KEY,		 0x2c1, { KEY_RESERVED } },
 	// Keyboard backlit
 	{ KE_IGNORE, 0x293, { KEY_KBDILLUMTOGGLE } },
 	{ KE_IGNORE, 0x294, { KEY_KBDILLUMUP } },

--- a/huawei-wmi.c
+++ b/huawei-wmi.c
@@ -87,7 +87,7 @@ static const struct key_entry huawei_wmi_keymap[] = {
 	{ KE_IGNORE, 0x294, { KEY_KBDILLUMUP } },
 	{ KE_IGNORE, 0x295, { KEY_KBDILLUMUP } },
 	// Ignore Ambient Light Sensoring
-	{ KE_KEY,		 0x2c1, { KEY_RESERVED } },
+	{ KE_KEY,    0x2c1, { KEY_RESERVED } },
 	{ KE_END,	 0 }
 };
 

--- a/huawei-wmi.c
+++ b/huawei-wmi.c
@@ -82,7 +82,7 @@ static const struct key_entry huawei_wmi_keymap[] = {
 	{ KE_KEY,    0x289, { KEY_WLAN } },
 	// Huawei |M| key
 	{ KE_KEY,    0x28a, { KEY_CONFIG } },
-	// Unknown key event
+	// Ignore Ambient Light Sensoring
 	{ KE_KEY,		 0x2c1, { KEY_RESERVED } },
 	// Keyboard backlit
 	{ KE_IGNORE, 0x293, { KEY_KBDILLUMTOGGLE } },

--- a/huawei-wmi.c
+++ b/huawei-wmi.c
@@ -82,12 +82,12 @@ static const struct key_entry huawei_wmi_keymap[] = {
 	{ KE_KEY,    0x289, { KEY_WLAN } },
 	// Huawei |M| key
 	{ KE_KEY,    0x28a, { KEY_CONFIG } },
-	// Ignore Ambient Light Sensoring
-	{ KE_KEY,		 0x2c1, { KEY_RESERVED } },
 	// Keyboard backlit
 	{ KE_IGNORE, 0x293, { KEY_KBDILLUMTOGGLE } },
 	{ KE_IGNORE, 0x294, { KEY_KBDILLUMUP } },
 	{ KE_IGNORE, 0x295, { KEY_KBDILLUMUP } },
+	// Ignore Ambient Light Sensoring
+	{ KE_KEY,		 0x2c1, { KEY_RESERVED } },
 	{ KE_END,	 0 }
 };
 


### PR DESCRIPTION
Ignores the event 0x02c1 generated by the Ambient Light Sensoring in Huawei X Pro 2022 laptop.