### PR TITLE
Remove throwing obsolete call to ledtrig 

### DIFF
--- a/huawei-wmi.c
+++ b/huawei-wmi.c
@@ -397,7 +397,6 @@ static void huawei_wmi_leds_setup(struct device *dev)
 	huawei->cdev.max_brightness = 1;
 	huawei->cdev.brightness_set_blocking = &huawei_wmi_micmute_led_set;
 	huawei->cdev.default_trigger = "audio-micmute";
-	huawei->cdev.brightness = ledtrig_audio_get(LED_AUDIO_MICMUTE);
 	huawei->cdev.dev = dev;
 	huawei->cdev.flags = LED_CORE_SUSPENDRESUME;
 


### PR DESCRIPTION
As per #88 and https://github.com/aymanbagabas/Huawei-WMI/issues/88#issuecomment-2255486365 