### PR TITLE
Change driver_data to quirk_skip_kbdlight

### DIFF
--- a/huawei-wmi.c
+++ b/huawei-wmi.c
@@ -281,7 +281,7 @@ static const struct dmi_system_id huawei_quirks[] = {
 			DMI_MATCH(DMI_SYS_VENDOR, "HUAWEI"),
 			DMI_MATCH(DMI_PRODUCT_NAME, "NBLK-WAX9X")
 		},
-		.driver_data = &quirk_unknown
+		.driver_data = &quirk_skip_kbdlight
 	},
 	{
 		.callback = dmi_matched,


### PR DESCRIPTION
matebook-applet can handle the kbdlight. Tested on NBLK-WAX9X