### PR TITLE
Added more key mappings for Honor MagicBook Art 14 2024 (MRA-XXX)

### DIFF
--- a/huawei-wmi.c
+++ b/huawei-wmi.c
@@ -125,6 +125,7 @@ enum {
 };
 
 static const struct key_entry huawei_wmi_keymap[] = {
+	{ KE_KEY,     0x109,              { KEY_BATTERY } },
 	{ KE_KEY,     0x281,              { KEY_BRIGHTNESSDOWN } },
 	{ KE_KEY,     0x282,              { KEY_BRIGHTNESSUP } },
 	{ KE_KEY,     0x283,              { KEY_TOUCHPAD_ON } },
@@ -164,6 +165,8 @@ static const struct key_entry huawei_wmi_keymap[] = {
 	// Camera module slot
 	{ KE_KEY,     0x2e0,              { KEY_CAMERA_ACCESS_ENABLE } },
 	{ KE_KEY,     0x2e1,              { KEY_CAMERA_ACCESS_DISABLE } },
+	{ KE_KEY,     0x2e2,              { KEY_PROG2 } },
+	{ KE_KEY,     0x2e3,              { KEY_PROG3 } },
 	{ KE_END, 0 }
 };
 


### PR DESCRIPTION
`0x2e2`/`3` are camera detached/attached to the top of the screen.

`0x109` is charging unplugged for some reason, but I think it's suitable to display battery level on that.

Support in the GNOME extension is on the way.

> Note: I previously used `KEY_BATTERY` for Power Unlock (instead of `PROG1`), but reusing it is kind of backwards-compatible _(at least for my extension, which is probably the only userland software ever used that keycode)_, since it only used as a notification of an already-occured hardware action (the EC toggles modes by itself).