### PR TITLE
refactor(leds): rename micmute LED to platform::micmute

### DIFF
--- a/huawei-wmi.c
+++ b/huawei-wmi.c
@@ -486,7 +486,7 @@ static void huawei_wmi_leds_setup(struct device *dev)
 {
 	struct huawei_wmi *huawei = dev_get_drvdata(dev);
 
-	huawei->micmute_cdev.name = "huawei::micmute";
+	huawei->micmute_cdev.name = "platform::micmute";
 	huawei->micmute_cdev.max_brightness = 1;
 	huawei->micmute_cdev.brightness_set_blocking = &huawei_wmi_micmute_led_set;
 	huawei->micmute_cdev.default_trigger = "audio-micmute";


### PR DESCRIPTION
Rename the microphone-mute LED from `huawei::micmute` to `platform::micmute`.

This matches the naming convention used by the in-tree driver and other
platform LED implementations, and lets userspace integrations that key
off the standard `platform::micmute` name work without a Huawei-specific
override.

This is a user-visible name change: anything hard-coded against
`huawei::micmute` (custom udev rules, scripts targeting
`/sys/class/leds/huawei::micmute/`) will need to be updated to use
`platform::micmute` instead.